### PR TITLE
Implement more agressive parallelism

### DIFF
--- a/prover/arithmetic.go
+++ b/prover/arithmetic.go
@@ -4,28 +4,46 @@ import (
 	"bytes"
 	"math/big"
 
+	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
 	"github.com/iden3/go-circom-prover-verifier/types"
 	"github.com/iden3/go-iden3-crypto/ff"
 )
 
 func arrayOfZeroes(n int) []*big.Int {
-	var r []*big.Int
+	r := make([]*big.Int, n)
 	for i := 0; i < n; i++ {
-		r = append(r, new(big.Int).SetInt64(0))
+		r[i] = new(big.Int).SetInt64(0)
 	}
-	return r
+	return r[:]
 }
+
 func arrayOfZeroesE(n int) []*ff.Element {
-	var r []*ff.Element
+	r := make([]*ff.Element, n)
 	for i := 0; i < n; i++ {
-		r = append(r, ff.NewElement())
+		r[i] = ff.NewElement()
 	}
-	return r
+	return r[:]
+}
+
+func arrayOfZeroesG1(n int) []*bn256.G1 {
+	r := make([]*bn256.G1, n)
+	for i := 0; i < n; i++ {
+		r[i] = new(bn256.G1).ScalarBaseMult(big.NewInt(0))
+	}
+	return r[:]
+}
+
+func arrayOfZeroesG2(n int) []*bn256.G2 {
+	r := make([]*bn256.G2, n)
+	for i := 0; i < n; i++ {
+		r[i] = new(bn256.G2).ScalarBaseMult(big.NewInt(0))
+	}
+	return r[:]
 }
 
 func fAdd(a, b *big.Int) *big.Int {
 	ab := new(big.Int).Add(a, b)
-	return new(big.Int).Mod(ab, types.R)
+	return ab.Mod(ab, types.R)
 }
 
 func fSub(a, b *big.Int) *big.Int {
@@ -35,7 +53,7 @@ func fSub(a, b *big.Int) *big.Int {
 
 func fMul(a, b *big.Int) *big.Int {
 	ab := new(big.Int).Mul(a, b)
-	return new(big.Int).Mod(ab, types.R)
+	return ab.Mod(ab, types.R)
 }
 
 func fDiv(a, b *big.Int) *big.Int {
@@ -62,7 +80,7 @@ func fExp(base *big.Int, e *big.Int) *big.Int {
 			res = fMul(res, exp)
 		}
 		exp = fMul(exp, exp)
-		rem = new(big.Int).Rsh(rem, 1)
+		rem.Rsh(rem, 1)
 	}
 	return res
 }

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -69,7 +69,6 @@ func GenerateProof(pk *types.Pk, w types.Witness) (*types.Proof, []*big.Int, err
 	}
 
 	// BEGIN PAR
-	println("NVars", pk.NVars)
 	numcpu := runtime.NumCPU()
 
 	proofA := arrayOfZeroesG1(numcpu)
@@ -107,8 +106,6 @@ func GenerateProof(pk *types.Pk, w types.Witness) (*types.Proof, []*big.Int, err
 
 	h := calculateH(pk, w)
 
-	println("len(h)", len(h))
-
 	proof.A.Add(proof.A, pk.VkAlpha1)
 	proof.A.Add(proof.A, new(bn256.G1).ScalarMult(pk.VkDelta1, r))
 
@@ -139,7 +136,7 @@ func GenerateProof(pk *types.Pk, w types.Witness) (*types.Proof, []*big.Int, err
 
 	proof.C.Add(proof.C, new(bn256.G1).ScalarMult(proof.A, s))
 	proof.C.Add(proof.C, new(bn256.G1).ScalarMult(proofBG1[0], r))
-	rsneg := new(big.Int).Mod(new(big.Int).Neg(new(big.Int).Mul(r, s)), types.R) // fAdd & fMul
+	rsneg := new(big.Int).Mod(new(big.Int).Neg(new(big.Int).Mul(r, s)), types.R)
 	proof.C.Add(proof.C, new(bn256.G1).ScalarMult(pk.VkDelta1, rsneg))
 
 	pubSignals := w[1 : pk.NPublic+1]
@@ -182,7 +179,6 @@ func calculateH(pk *types.Pk, w types.Witness) []*big.Int {
 	r := int(math.Log2(float64(m))) + 1
 	roots := newRootsT()
 	roots.setRoots(r)
-	println("len(polASe)", len(polASe))
 
 	var wg2 sync.WaitGroup
 	wg2.Add(numcpu)


### PR DESCRIPTION
After a profile analysis I have observed that GenerateProof spends most of its time in two parts:
- first loop: 82%
- second loop: 15%

This PR implements a full parallel approach for the two loops using all the CPUs available.  The computation is first equally split into go routines and then joined.

Here are the benchmark results on my laptop (Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz), for generating a proof of 5k constraints:
- `master`: 3.024627965s
- `feature/paralelism2`: 933.58549ms