### PR TITLE
Add proof parsers to string (decimal & hex)

### DIFF
--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -467,8 +467,35 @@ func stringToG2(h [][]string) (*bn256.G2, error) {
 	return p, err
 }
 
-// ProofToJson outputs the Proof i Json format
-func ProofToJson(p *types.Proof) ([]byte, error) {
+// ProofStringToSmartContractFormat converts the ProofString to a ProofString in the SmartContract format in a ProofString structure
+func ProofStringToSmartContractFormat(s ProofString) ProofString {
+	var rs ProofString
+	rs.A = make([]string, 2)
+	rs.B = make([][]string, 2)
+	rs.B[0] = make([]string, 2)
+	rs.B[1] = make([]string, 2)
+	rs.C = make([]string, 2)
+
+	rs.A[0] = s.A[0]
+	rs.A[1] = s.A[1]
+	rs.B[0][0] = s.B[0][1]
+	rs.B[0][1] = s.B[0][0]
+	rs.B[1][0] = s.B[1][1]
+	rs.B[1][1] = s.B[1][0]
+	rs.C[0] = s.C[0]
+	rs.C[1] = s.C[1]
+	rs.Protocol = s.Protocol
+	return rs
+}
+
+// ProofToSmartContractFormat converts the *types.Proof to a ProofString in the SmartContract format in a ProofString structure
+func ProofToSmartContractFormat(p *types.Proof) ProofString {
+	s := ProofToString(p)
+	return ProofStringToSmartContractFormat(s)
+}
+
+// ProofToString converts the Proof to ProofString
+func ProofToString(p *types.Proof) ProofString {
 	var ps ProofString
 	ps.A = make([]string, 3)
 	ps.B = make([][]string, 3)
@@ -497,10 +524,55 @@ func ProofToJson(p *types.Proof) ([]byte, error) {
 
 	ps.Protocol = "groth"
 
+	return ps
+}
+
+// ProofToJson outputs the Proof i Json format
+func ProofToJson(p *types.Proof) ([]byte, error) {
+	ps := ProofToString(p)
 	return json.Marshal(ps)
 }
 
-// ParseWitness parses binary file representation of the Witness into the Witness struct
+// ProofToHex converts the Proof to ProofString with hexadecimal strings
+func ProofToHex(p *types.Proof) ProofString {
+	var ps ProofString
+	ps.A = make([]string, 3)
+	ps.B = make([][]string, 3)
+	ps.B[0] = make([]string, 2)
+	ps.B[1] = make([]string, 2)
+	ps.B[2] = make([]string, 2)
+	ps.C = make([]string, 3)
+
+	a := p.A.Marshal()
+	ps.A[0] = "0x" + hex.EncodeToString(new(big.Int).SetBytes(a[:32]).Bytes())
+	ps.A[1] = "0x" + hex.EncodeToString(new(big.Int).SetBytes(a[32:64]).Bytes())
+	ps.A[2] = "1"
+
+	b := p.B.Marshal()
+	ps.B[0][1] = "0x" + hex.EncodeToString(new(big.Int).SetBytes(b[:32]).Bytes())
+	ps.B[0][0] = "0x" + hex.EncodeToString(new(big.Int).SetBytes(b[32:64]).Bytes())
+	ps.B[1][1] = "0x" + hex.EncodeToString(new(big.Int).SetBytes(b[64:96]).Bytes())
+	ps.B[1][0] = "0x" + hex.EncodeToString(new(big.Int).SetBytes(b[96:128]).Bytes())
+	ps.B[2][0] = "1"
+	ps.B[2][1] = "0"
+
+	c := p.C.Marshal()
+	ps.C[0] = "0x" + hex.EncodeToString(new(big.Int).SetBytes(c[:32]).Bytes())
+	ps.C[1] = "0x" + hex.EncodeToString(new(big.Int).SetBytes(c[32:64]).Bytes())
+	ps.C[2] = "1"
+
+	ps.Protocol = "groth"
+
+	return ps
+}
+
+// ProofToJsonHex outputs the Proof i Json format with hexadecimal strings
+func ProofToJsonHex(p *types.Proof) ([]byte, error) {
+	ps := ProofToHex(p)
+	return json.Marshal(ps)
+}
+
+// ParseWitnessBin parses binary file representation of the Witness into the Witness struct
 func ParseWitnessBin(f *os.File) (types.Witness, error) {
 	var w types.Witness
 	r := bufio.NewReader(f)

--- a/parsers/parsers_test.go
+++ b/parsers/parsers_test.go
@@ -172,3 +172,27 @@ func TestParseWitnessBin(t *testing.T) {
 	testCircuitParseWitnessBin(t, "circuit1k")
 	testCircuitParseWitnessBin(t, "circuit5k")
 }
+
+func TestProofSmartContractFormat(t *testing.T) {
+	proofJson, err := ioutil.ReadFile("../testdata/circuit1k/proof.json")
+	require.Nil(t, err)
+	proof, err := ParseProof(proofJson)
+	require.Nil(t, err)
+	pS := ProofToString(proof)
+
+	pSC := ProofToSmartContractFormat(proof)
+	assert.Nil(t, err)
+	assert.Equal(t, pS.A[0], pSC.A[0])
+	assert.Equal(t, pS.A[1], pSC.A[1])
+	assert.Equal(t, pS.B[0][0], pSC.B[0][1])
+	assert.Equal(t, pS.B[0][1], pSC.B[0][0])
+	assert.Equal(t, pS.B[1][0], pSC.B[1][1])
+	assert.Equal(t, pS.B[1][1], pSC.B[1][0])
+	assert.Equal(t, pS.C[0], pSC.C[0])
+	assert.Equal(t, pS.C[1], pSC.C[1])
+	assert.Equal(t, pS.Protocol, pSC.Protocol)
+
+	pSC2 := ProofStringToSmartContractFormat(pS)
+	assert.Equal(t, pSC, pSC2)
+
+}

--- a/prover/gextra_test.go
+++ b/prover/gextra_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
-	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
 	"math/big"
 	"testing"
 	"time"
+
+	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
 )
 
 const (
@@ -60,31 +61,31 @@ func TestTableG1(t *testing.T) {
 
 	for gsize := 2; gsize < 10; gsize++ {
 		ntables := int((n + gsize - 1) / gsize)
-		table := make([]TableG1, ntables)
+		table := make([]tableG1, ntables)
 
 		for i := 0; i < ntables-1; i++ {
-			table[i].NewTableG1(arrayG1[i*gsize:(i+1)*gsize], gsize, true)
+			table[i].newTableG1(arrayG1[i*gsize:(i+1)*gsize], gsize, true)
 		}
-		table[ntables-1].NewTableG1(arrayG1[(ntables-1)*gsize:], gsize, true)
+		table[ntables-1].newTableG1(arrayG1[(ntables-1)*gsize:], gsize, true)
 
 		beforeT = time.Now()
 		Q2 := new(bn256.G1).ScalarBaseMult(new(big.Int))
 		for i := 0; i < ntables-1; i++ {
-			Q2 = table[i].MulTableG1(arrayW[i*gsize:(i+1)*gsize], Q2, gsize)
+			Q2 = table[i].mulTableG1(arrayW[i*gsize:(i+1)*gsize], Q2, gsize)
 		}
-		Q2 = table[ntables-1].MulTableG1(arrayW[(ntables-1)*gsize:], Q2, gsize)
+		Q2 = table[ntables-1].mulTableG1(arrayW[(ntables-1)*gsize:], Q2, gsize)
 		fmt.Printf("Gsize : %d, TMult time elapsed: %s\n", gsize, time.Since(beforeT))
 
 		beforeT = time.Now()
-		Q3 := ScalarMultG1(arrayG1, arrayW, nil, gsize)
+		Q3 := scalarMultG1(arrayG1, arrayW, nil, gsize)
 		fmt.Printf("Gsize : %d, TMult time elapsed (inc table comp): %s\n", gsize, time.Since(beforeT))
 
 		beforeT = time.Now()
-		Q4 := MulTableNoDoubleG1(table, arrayW, nil, gsize)
+		Q4 := mulTableNoDoubleG1(table, arrayW, nil, gsize)
 		fmt.Printf("Gsize : %d, TMultNoDouble time elapsed: %s\n", gsize, time.Since(beforeT))
 
 		beforeT = time.Now()
-		Q5 := ScalarMultNoDoubleG1(arrayG1, arrayW, nil, gsize)
+		Q5 := scalarMultNoDoubleG1(arrayG1, arrayW, nil, gsize)
 		fmt.Printf("Gsize : %d, TMultNoDouble time elapsed (inc table comp): %s\n", gsize, time.Since(beforeT))
 
 		if bytes.Compare(Q1.Marshal(), Q2.Marshal()) != 0 {
@@ -119,31 +120,31 @@ func TestTableG2(t *testing.T) {
 
 	for gsize := 2; gsize < 10; gsize++ {
 		ntables := int((n + gsize - 1) / gsize)
-		table := make([]TableG2, ntables)
+		table := make([]tableG2, ntables)
 
 		for i := 0; i < ntables-1; i++ {
-			table[i].NewTableG2(arrayG2[i*gsize:(i+1)*gsize], gsize, false)
+			table[i].newTableG2(arrayG2[i*gsize:(i+1)*gsize], gsize, false)
 		}
-		table[ntables-1].NewTableG2(arrayG2[(ntables-1)*gsize:], gsize, false)
+		table[ntables-1].newTableG2(arrayG2[(ntables-1)*gsize:], gsize, false)
 
 		beforeT = time.Now()
 		Q2 := new(bn256.G2).ScalarBaseMult(new(big.Int))
 		for i := 0; i < ntables-1; i++ {
-			Q2 = table[i].MulTableG2(arrayW[i*gsize:(i+1)*gsize], Q2, gsize)
+			Q2 = table[i].mulTableG2(arrayW[i*gsize:(i+1)*gsize], Q2, gsize)
 		}
-		Q2 = table[ntables-1].MulTableG2(arrayW[(ntables-1)*gsize:], Q2, gsize)
+		Q2 = table[ntables-1].mulTableG2(arrayW[(ntables-1)*gsize:], Q2, gsize)
 		fmt.Printf("Gsize : %d, TMult time elapsed: %s\n", gsize, time.Since(beforeT))
 
 		beforeT = time.Now()
-		Q3 := ScalarMultG2(arrayG2, arrayW, nil, gsize)
+		Q3 := scalarMultG2(arrayG2, arrayW, nil, gsize)
 		fmt.Printf("Gsize : %d, TMult time elapsed (inc table comp): %s\n", gsize, time.Since(beforeT))
 
 		beforeT = time.Now()
-		Q4 := MulTableNoDoubleG2(table, arrayW, nil, gsize)
+		Q4 := mulTableNoDoubleG2(table, arrayW, nil, gsize)
 		fmt.Printf("Gsize : %d, TMultNoDouble time elapsed: %s\n", gsize, time.Since(beforeT))
 
 		beforeT = time.Now()
-		Q5 := ScalarMultNoDoubleG2(arrayG2, arrayW, nil, gsize)
+		Q5 := scalarMultNoDoubleG2(arrayG2, arrayW, nil, gsize)
 		fmt.Printf("Gsize : %d, TMultNoDouble time elapsed (inc table comp): %s\n", gsize, time.Since(beforeT))
 
 		if bytes.Compare(Q1.Marshal(), Q2.Marshal()) != 0 {

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -10,7 +10,7 @@ import (
 	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
 	"github.com/iden3/go-circom-prover-verifier/types"
 	"github.com/iden3/go-iden3-crypto/utils"
-        //"fmt"
+	//"fmt"
 )
 
 // Proof is the data structure of the Groth16 zkSNARK proof
@@ -45,7 +45,7 @@ type Witness []*big.Int
 
 // Group Size
 const (
-    GSIZE = 6
+	GSIZE = 6
 )
 
 func randBigInt() (*big.Int, error) {
@@ -81,34 +81,34 @@ func GenerateProof(pk *types.Pk, w types.Witness) (*types.Proof, []*big.Int, err
 	proofB := arrayOfZeroesG2(numcpu)
 	proofC := arrayOfZeroesG1(numcpu)
 	proofBG1 := arrayOfZeroesG1(numcpu)
-        gsize := GSIZE
+	gsize := GSIZE
 	var wg1 sync.WaitGroup
 	wg1.Add(numcpu)
 	for _cpu, _ranges := range ranges(pk.NVars, numcpu) {
 		// split 1
 		go func(cpu int, ranges [2]int) {
-                        proofA[cpu] = ScalarMultNoDoubleG1(pk.A[ranges[0]:ranges[1]],
-                                                           w[ranges[0]:ranges[1]],
-                                                           proofA[cpu],
-                                                           gsize)
-                        proofB[cpu] = ScalarMultNoDoubleG2(pk.B2[ranges[0]:ranges[1]],
-                                                           w[ranges[0]:ranges[1]],
-                                                           proofB[cpu],
-                                                           gsize)
-                        proofBG1[cpu] = ScalarMultNoDoubleG1(pk.B1[ranges[0]:ranges[1]],
-                                                           w[ranges[0]:ranges[1]],
-                                                           proofBG1[cpu],
-                                                           gsize)
-                        min_lim := pk.NPublic+1
-                        if ranges[0] > pk.NPublic+1 {
-                           min_lim = ranges[0]
-                        }
-                        if ranges[1] > pk.NPublic + 1 {
-                            proofC[cpu] = ScalarMultNoDoubleG1(pk.C[min_lim:ranges[1]],
-                                                           w[min_lim:ranges[1]],
-                                                           proofC[cpu],
-                                                           gsize)
-                        }
+			proofA[cpu] = scalarMultNoDoubleG1(pk.A[ranges[0]:ranges[1]],
+				w[ranges[0]:ranges[1]],
+				proofA[cpu],
+				gsize)
+			proofB[cpu] = scalarMultNoDoubleG2(pk.B2[ranges[0]:ranges[1]],
+				w[ranges[0]:ranges[1]],
+				proofB[cpu],
+				gsize)
+			proofBG1[cpu] = scalarMultNoDoubleG1(pk.B1[ranges[0]:ranges[1]],
+				w[ranges[0]:ranges[1]],
+				proofBG1[cpu],
+				gsize)
+			minLim := pk.NPublic + 1
+			if ranges[0] > pk.NPublic+1 {
+				minLim = ranges[0]
+			}
+			if ranges[1] > pk.NPublic+1 {
+				proofC[cpu] = scalarMultNoDoubleG1(pk.C[minLim:ranges[1]],
+					w[minLim:ranges[1]],
+					proofC[cpu],
+					gsize)
+			}
 			wg1.Done()
 		}(_cpu, _ranges)
 	}
@@ -142,10 +142,10 @@ func GenerateProof(pk *types.Pk, w types.Witness) (*types.Proof, []*big.Int, err
 	for _cpu, _ranges := range ranges(len(h), numcpu) {
 		// split 2
 		go func(cpu int, ranges [2]int) {
-                        proofC[cpu] = ScalarMultNoDoubleG1(pk.HExps[ranges[0]:ranges[1]],
-                                                           h[ranges[0]:ranges[1]],
-                                                           proofC[cpu],
-                                                           gsize)
+			proofC[cpu] = scalarMultNoDoubleG1(pk.HExps[ranges[0]:ranges[1]],
+				h[ranges[0]:ranges[1]],
+				proofC[cpu],
+				gsize)
 			wg2.Done()
 		}(_cpu, _ranges)
 	}

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -16,8 +16,8 @@ import (
 func TestCircuitsGenerateProof(t *testing.T) {
 	testCircuitGenerateProof(t, "circuit1k") // 1000 constraints
 	testCircuitGenerateProof(t, "circuit5k") // 5000 constraints
-        //testCircuitGenerateProof(t, "circuit10k") // 10000 constraints
-        //testCircuitGenerateProof(t, "circuit20k") // 20000 constraints
+	//testCircuitGenerateProof(t, "circuit10k") // 10000 constraints
+	//testCircuitGenerateProof(t, "circuit20k") // 20000 constraints
 }
 
 func testCircuitGenerateProof(t *testing.T, circuit string) {


### PR DESCRIPTION
Also adds ProofToSmartContractFormat, which returns a ProofString as the
proof.B elements swap is not a valid point for the bn256.G2 format.
Where the output is valid for the `verifier.sol` proof.B format https://github.com/iden3/contracts/blob/feature/ph-2/contracts/lib/verifier.sol#L215

Also unexports internal structs and methods of the prover package.
Also apply golint.