### PR TITLE
Add ProvingKey binary parser

### DIFF
--- a/parsers/parsers_test.go
+++ b/parsers/parsers_test.go
@@ -196,3 +196,63 @@ func TestProofSmartContractFormat(t *testing.T) {
 	assert.Equal(t, pSC, pSC2)
 
 }
+
+func testCircuitParsePkBin(t *testing.T, circuit string) {
+	pkBinFile, err := os.Open("../testdata/" + circuit + "/proving_key.bin")
+	require.Nil(t, err)
+	defer pkBinFile.Close()
+	pk, err := ParsePkBin(pkBinFile)
+	require.Nil(t, err)
+
+	pkJson, err := ioutil.ReadFile("../testdata/" + circuit + "/proving_key.json")
+	require.Nil(t, err)
+	pkJ, err := ParsePk(pkJson)
+	require.Nil(t, err)
+
+	assert.Equal(t, pkJ.NVars, pk.NVars)
+	assert.Equal(t, pkJ.NPublic, pk.NPublic)
+	assert.Equal(t, pkJ.DomainSize, pk.DomainSize)
+	assert.Equal(t, pkJ.VkAlpha1, pk.VkAlpha1)
+	assert.Equal(t, pkJ.VkBeta1, pk.VkBeta1)
+	assert.Equal(t, pkJ.VkDelta1, pk.VkDelta1)
+	assert.Equal(t, pkJ.VkDelta2, pk.VkDelta2)
+	assert.Equal(t, pkJ.PolsA, pk.PolsA)
+	assert.Equal(t, pkJ.PolsB, pk.PolsB)
+	assert.Equal(t, pkJ.A, pk.A)
+	assert.Equal(t, pkJ.B1, pk.B1)
+	assert.Equal(t, pkJ.B2, pk.B2)
+	assert.Equal(t, pkJ.C, pk.C)
+	assert.Equal(t, pkJ.HExps[:pkJ.DomainSize], pk.HExps[:pk.DomainSize]) // circom behaviour
+}
+
+func TestParsePkBin(t *testing.T) {
+	testCircuitParsePkBin(t, "circuit1k")
+	testCircuitParsePkBin(t, "circuit5k")
+}
+
+func benchmarkParsePk(b *testing.B, circuit string) {
+	pkJson, err := ioutil.ReadFile("../testdata/" + circuit + "/proving_key.json")
+	require.Nil(b, err)
+
+	pkBinFile, err := os.Open("../testdata/" + circuit + "/proving_key.bin")
+	require.Nil(b, err)
+	defer pkBinFile.Close()
+
+	b.Run("Parse Pk bin "+circuit, func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			ParsePk(pkJson)
+		}
+	})
+	b.Run("Parse Pk json "+circuit, func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			ParsePkBin(pkBinFile)
+		}
+	})
+}
+
+func BenchmarkParsePk(b *testing.B) {
+	benchmarkParsePk(b, "circuit1k")
+	benchmarkParsePk(b, "circuit5k")
+	// benchmarkParsePk(b, "circuit10k")
+	// benchmarkParsePk(b, "circuit20k")
+}

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -16,25 +17,38 @@ import (
 func TestCircuitsGenerateProof(t *testing.T) {
 	testCircuitGenerateProof(t, "circuit1k") // 1000 constraints
 	testCircuitGenerateProof(t, "circuit5k") // 5000 constraints
-	//testCircuitGenerateProof(t, "circuit10k") // 10000 constraints
-	//testCircuitGenerateProof(t, "circuit20k") // 20000 constraints
+	// testCircuitGenerateProof(t, "circuit10k") // 10000 constraints
+	// testCircuitGenerateProof(t, "circuit20k") // 20000 constraints
 }
 
 func testCircuitGenerateProof(t *testing.T, circuit string) {
-	provingKeyJson, err := ioutil.ReadFile("../testdata/" + circuit + "/proving_key.json")
+	// using json provingKey file
+	// provingKeyJson, err := ioutil.ReadFile("../testdata/" + circuit + "/proving_key.json")
+	// require.Nil(t, err)
+	// pk, err := parsers.ParsePk(provingKeyJson)
+	// require.Nil(t, err)
+	// witnessJson, err := ioutil.ReadFile("../testdata/" + circuit + "/witness.json")
+	// require.Nil(t, err)
+	// w, err := parsers.ParseWitness(witnessJson)
+	// require.Nil(t, err)
+
+	// using bin provingKey file
+	pkBinFile, err := os.Open("../testdata/" + circuit + "/proving_key.bin")
 	require.Nil(t, err)
-	pk, err := parsers.ParsePk(provingKeyJson)
+	defer pkBinFile.Close()
+	pk, err := parsers.ParsePkBin(pkBinFile)
 	require.Nil(t, err)
 
-	witnessJson, err := ioutil.ReadFile("../testdata/" + circuit + "/witness.json")
+	witnessBinFile, err := os.Open("../testdata/" + circuit + "/witness.bin")
 	require.Nil(t, err)
-	w, err := parsers.ParseWitness(witnessJson)
+	defer witnessBinFile.Close()
+	w, err := parsers.ParseWitnessBin(witnessBinFile)
 	require.Nil(t, err)
 
 	beforeT := time.Now()
 	proof, pubSignals, err := GenerateProof(pk, w)
 	assert.Nil(t, err)
-	fmt.Println("proof generation time elapsed:", time.Since(beforeT))
+	fmt.Println("proof generation time for "+circuit+" elapsed:", time.Since(beforeT))
 
 	proofStr, err := parsers.ProofToJson(proof)
 	assert.Nil(t, err)

--- a/types/types.go
+++ b/types/types.go
@@ -6,6 +6,8 @@ import (
 	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
 )
 
+var Q, _ = new(big.Int).SetString("21888242871839275222246405745257275088696311157297823662689037894645226208583", 10)
+
 // R is the mod of the finite field
 var R, _ = new(big.Int).SetString("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10)
 


### PR DESCRIPTION
The time on the parsing doesn't improve, as the data from the binary
file needs to be converted to `affine` representation, and then parsed
into the `bn256.G1` & `bn256.G2` formats (Montgomery). But the size of
the ProvingKey files in binary is much smaller, so will be better
handled by the smarthpones.

- Parse time benchmarks:
```
BenchmarkParsePk/Parse_Pk_bin_circuit1k-4         	       2	 563729994 ns/op
BenchmarkParsePk/Parse_Pk_json_circuit1k-4        	  635641	      1941 ns/op
BenchmarkParsePk/Parse_Pk_bin_circuit5k-4         	       1	2637941658 ns/op
BenchmarkParsePk/Parse_Pk_json_circuit5k-4        	       1	2986560185 ns/op
BenchmarkParsePk/Parse_Pk_bin_circuit10k-4        	       1	5337639150 ns/op
BenchmarkParsePk/Parse_Pk_json_circuit10k-4       	       1	6149568824 ns/op
BenchmarkParsePk/Parse_Pk_bin_circuit20k-4        	       1	10533654623 ns/op
BenchmarkParsePk/Parse_Pk_json_circuit20k-4       	       1	11657326851 ns/op
```

- Size of ProvingKey file for a circuit of 50k constraints:
```
circuit 20k constraints:
10097812 bytes of proving_key.bin
29760049 bytes of proving_key.json

circuit 50k constraints:
24194964 bytes of proving_key.bin
71484081 bytes of proving_key.json
```

I have pending for a future iteration, to split the reads from the conversions and to parallelize conversions, but for now we can close the current phase with this as this at least allows to work with smaller file sizes.
Also a future iteration could be to use a own provingKey file format, so the parsing would be much faster.