### PR TITLE
Add own go-circom ProvingKey Bin format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Compile circuits and execute Go tests
       run: |
         cd testdata && sh ./compile-circuits.sh && cd ..
-        go run cli/cli.go -prove -provingkey=testdata/circuit1k/proving_key.json -witness=testdata/circuit1k/witness.json -proof=testdata/circuit1k/proof.json -public=testdata/circuit1k/public.json
-        go run cli/cli.go -prove -provingkey=testdata/circuit5k/proving_key.json -witness=testdata/circuit5k/witness.json -proof=testdata/circuit5k/proof.json -public=testdata/circuit5k/public.json
+        go run cli/cli.go -prove -pk=testdata/circuit1k/proving_key.json -witness=testdata/circuit1k/witness.json -proof=testdata/circuit1k/proof.json -public=testdata/circuit1k/public.json
+        go run cli/cli.go -prove -pk=testdata/circuit5k/proving_key.json -witness=testdata/circuit5k/witness.json -proof=testdata/circuit5k/proof.json -public=testdata/circuit5k/public.json
         go test ./...

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -21,12 +21,14 @@ func main() {
 
 	prove := flag.Bool("prove", false, "prover mode")
 	verify := flag.Bool("verify", false, "verifier mode")
+	convert := flag.Bool("convert", false, "convert mode, to convert between proving_key.json to proving_key.go.bin")
 
-	provingKeyPath := flag.String("provingkey", "proving_key.json", "provingKey path")
+	provingKeyPath := flag.String("pk", "proving_key.json", "provingKey path")
 	witnessPath := flag.String("witness", "witness.json", "witness path")
 	proofPath := flag.String("proof", "proof.json", "proof path")
-	verificationKeyPath := flag.String("verificationkey", "verification_key.json", "verificationKey path")
+	verificationKeyPath := flag.String("vk", "verification_key.json", "verificationKey path")
 	publicPath := flag.String("public", "public.json", "public signals path")
+	provingKeyBinPath := flag.String("pkbin", "proving_key.go.bin", "provingKey Bin path")
 
 	flag.Parse()
 
@@ -38,6 +40,12 @@ func main() {
 		os.Exit(0)
 	} else if *verify {
 		err := cmdVerify(*proofPath, *verificationKeyPath, *publicPath)
+		if err != nil {
+			fmt.Println("Error:", err)
+		}
+		os.Exit(0)
+	} else if *convert {
+		err := cmdConvert(*provingKeyPath, *provingKeyBinPath)
 		if err != nil {
 			fmt.Println("Error:", err)
 		}
@@ -131,5 +139,27 @@ func cmdVerify(proofPath, verificationKeyPath, publicPath string) error {
 
 	v := verifier.Verify(vk, proof, public)
 	fmt.Println("verification:", v)
+	return nil
+}
+
+func cmdConvert(provingKeyPath, provingKeyBinPath string) error {
+	fmt.Println("Convertion tool")
+
+	provingKeyJson, err := ioutil.ReadFile(provingKeyPath)
+	if err != nil {
+		return err
+	}
+	pk, err := parsers.ParsePk(provingKeyJson)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Converting proving key json (%s)\nto go proving key binary (%s)\n", provingKeyPath, provingKeyBinPath)
+	pkGBin, err := parsers.PkToGoBin(pk)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(provingKeyBinPath, pkGBin, 0644)
+
 	return nil
 }

--- a/parsers/parsers_test.go
+++ b/parsers/parsers_test.go
@@ -253,11 +253,11 @@ func testGoCircomPkFormat(t *testing.T, circuit string) {
 
 	pkGBin, err := PkToGoBin(pk)
 	require.Nil(t, err)
-	err = ioutil.WriteFile("../testdata/"+circuit+"/proving_key_go.bin", pkGBin, 0644)
+	err = ioutil.WriteFile("../testdata/"+circuit+"/proving_key.go.bin", pkGBin, 0644)
 	assert.Nil(t, err)
 
 	// parse ProvingKeyGo
-	pkGoBinFile, err := os.Open("../testdata/" + circuit + "/proving_key_go.bin")
+	pkGoBinFile, err := os.Open("../testdata/" + circuit + "/proving_key.go.bin")
 	require.Nil(t, err)
 	defer pkGoBinFile.Close()
 	pkG, err := ParsePkGoBin(pkGoBinFile)
@@ -291,7 +291,7 @@ func benchmarkParsePk(b *testing.B, circuit string) {
 	require.Nil(b, err)
 	defer pkBinFile.Close()
 
-	pkGoBinFile, err := os.Open("../testdata/" + circuit + "/proving_key_go.bin")
+	pkGoBinFile, err := os.Open("../testdata/" + circuit + "/proving_key.go.bin")
 	require.Nil(b, err)
 	defer pkGoBinFile.Close()
 

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -22,7 +22,7 @@ func TestCircuitsGenerateProof(t *testing.T) {
 }
 
 func testCircuitGenerateProof(t *testing.T, circuit string) {
-	// using json provingKey file
+	// Using json provingKey file:
 	// provingKeyJson, err := ioutil.ReadFile("../testdata/" + circuit + "/proving_key.json")
 	// require.Nil(t, err)
 	// pk, err := parsers.ParsePk(provingKeyJson)
@@ -32,11 +32,18 @@ func testCircuitGenerateProof(t *testing.T, circuit string) {
 	// w, err := parsers.ParseWitness(witnessJson)
 	// require.Nil(t, err)
 
-	// using bin provingKey file
-	pkBinFile, err := os.Open("../testdata/" + circuit + "/proving_key.bin")
+	// Using bin provingKey file:
+	// pkBinFile, err := os.Open("../testdata/" + circuit + "/proving_key.bin")
+	// require.Nil(t, err)
+	// defer pkBinFile.Close()
+	// pk, err := parsers.ParsePkBin(pkBinFile)
+	// require.Nil(t, err)
+
+	// Using go bin provingKey file:
+	pkGoBinFile, err := os.Open("../testdata/" + circuit + "/proving_key.go.bin")
 	require.Nil(t, err)
-	defer pkBinFile.Close()
-	pk, err := parsers.ParsePkBin(pkBinFile)
+	defer pkGoBinFile.Close()
+	pk, err := parsers.ParsePkGoBin(pkGoBinFile)
 	require.Nil(t, err)
 
 	witnessBinFile, err := os.Open("../testdata/" + circuit + "/witness.bin")

--- a/testdata/clean-gereated-files.sh
+++ b/testdata/clean-gereated-files.sh
@@ -7,3 +7,4 @@ rm */*.cpp
 rm */*.sym
 rm */*.r1cs
 rm */*.sol
+rm */*.bin

--- a/testdata/compile-circuits.sh
+++ b/testdata/compile-circuits.sh
@@ -45,19 +45,23 @@ compile_and_ts_and_witness
 
 cd ../
 
-echo "convert witness & pk of circuit1k to bin"
+echo "convert witness & pk of circuit1k to bin & go bin"
 node node_modules/wasmsnark/tools/buildwitness.js -i circuit1k/witness.json -o circuit1k/witness.bin
 node node_modules/wasmsnark/tools/buildpkey.js -i circuit1k/proving_key.json -o circuit1k/proving_key.bin
+go run ../cli/cli.go -convert -pk circuit1k/proving_key.json -pkbin circuit1k/proving_key.go.bin
 
-echo "convert witness & pk of circuit5k to bin"
+echo "convert witness & pk of circuit5k to bin & go bin"
 node node_modules/wasmsnark/tools/buildwitness.js -i circuit5k/witness.json -o circuit5k/witness.bin
 node node_modules/wasmsnark/tools/buildpkey.js -i circuit5k/proving_key.json -o circuit5k/proving_key.bin
+go run ../cli/cli.go -convert -pk circuit5k/proving_key.json -pkbin circuit5k/proving_key.go.bin
 
-# echo "convert witness & pk of circuit10k to bin"
+# echo "convert witness & pk of circuit10k to bin & go bin"
 # node node_modules/wasmsnark/tools/buildwitness.js -i circuit10k/witness.json -o circuit10k/witness.bin
 # node node_modules/wasmsnark/tools/buildpkey.js -i circuit10k/proving_key.json -o circuit10k/proving_key.bin
+# go run ../cli/cli.go -convert -pk circuit10k/proving_key.json -pkbin circuit10k/proving_key.go.bin
 # 
-# echo "convert witness & pk of circuit20k to bin"
+# echo "convert witness & pk of circuit20k to bin & go bin"
 # node node_modules/wasmsnark/tools/buildwitness.js -i circuit20k/witness.json -o circuit20k/witness.bin
 # node node_modules/wasmsnark/tools/buildpkey.js -i circuit20k/proving_key.json -o circuit20k/proving_key.bin
+# go run ../cli/cli.go -convert -pk circuit20k/proving_key.json -pkbin circuit20k/proving_key.go.bin
 


### PR DESCRIPTION
Add own go-circom ProvingKey Bin format
Add parsers from bin to pk and from pk to bin.
Add cli to convert from `proving_key.json` to `proving_key_go.bin` (which is used in the `compile-circuits.sh` script).

 ```
BenchmarkParsePk/ParsePkJson_circuit1k-4                  595215              1954 ns/op
BenchmarkParsePk/ParsePkBin_circuit1k-4                        2         522174688 ns/op
BenchmarkParsePk/ParsePkGoBin_circuit1k-4                 623182              1901 ns/op
BenchmarkParsePk/ParsePkJson_circuit5k-4                       1        2861959141 ns/op
BenchmarkParsePk/ParsePkBin_circuit5k-4                        1        2610638932 ns/op
BenchmarkParsePk/ParsePkGoBin_circuit5k-4                 612906              1907 ns/op
BenchmarkParsePk/ParsePkJson_circuit10k-4                      1        5793696755 ns/op
BenchmarkParsePk/ParsePkBin_circuit10k-4                       1        5204251056 ns/op
BenchmarkParsePk/ParsePkGoBin_circuit10k-4                603478              1913 ns/op
BenchmarkParsePk/ParsePkJson_circuit20k-4                      1        11404022165 ns/op
BenchmarkParsePk/ParsePkBin_circuit20k-4                       1        10392012613 ns/op
BenchmarkParsePk/ParsePkGoBin_circuit20k-4                620488              1921 ns/op
```

For the `10k` constraints circuit is arround `1_368_976x` improvement.
For the `20k` constraints circuit is arround `5_409_689x` improvement.
