### PR TITLE
Fix pk parser benchmarks

### DIFF
--- a/parsers/parsers_test.go
+++ b/parsers/parsers_test.go
@@ -297,17 +297,22 @@ func benchmarkParsePk(b *testing.B, circuit string) {
 
 	b.Run("ParsePkJson "+circuit, func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ParsePkBin(pkBinFile)
+			_, err = ParsePk(pkJson)
+			require.Nil(b, err)
 		}
 	})
 	b.Run("ParsePkBin "+circuit, func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ParsePk(pkJson)
+			pkBinFile.Seek(0, 0)
+			_, err = ParsePkBin(pkBinFile)
+			require.Nil(b, err)
 		}
 	})
 	b.Run("ParsePkGoBin "+circuit, func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ParsePkGoBin(pkBinFile)
+			pkGoBinFile.Seek(0, 0)
+			_, err = ParsePkGoBin(pkGoBinFile)
+			require.Nil(b, err)
 		}
 	})
 }


### PR DESCRIPTION
Parsers were working correctly, but the benchmarks had errors.

The benchmarks in the commit d1b3979eb663e1d6b2db672bca154c1a839b9cef
are incorrect, correct ones are:

```
BenchmarkParsePk/ParsePkJson_circuit1k-4         	       2	 529437960 ns/op
BenchmarkParsePk/ParsePkBin_circuit1k-4          	       2	 607792597 ns/op
BenchmarkParsePk/ParsePkGoBin_circuit1k-4        	       2	 540594611 ns/op
BenchmarkParsePk/ParsePkJson_circuit5k-4         	       1	2769819086 ns/op
BenchmarkParsePk/ParsePkBin_circuit5k-4          	       1	3094913319 ns/op
BenchmarkParsePk/ParsePkGoBin_circuit5k-4        	       1	2404651389 ns/op
BenchmarkParsePk/ParsePkJson_circuit10k-4        	       1	5374917709 ns/op
BenchmarkParsePk/ParsePkBin_circuit10k-4         	       1	5756633515 ns/op
BenchmarkParsePk/ParsePkGoBin_circuit10k-4       	       1	4782081310 ns/op
BenchmarkParsePk/ParsePkJson_circuit20k-4        	       1	10374987398 ns/op
BenchmarkParsePk/ParsePkBin_circuit20k-4         	       1	11528361584 ns/op
BenchmarkParsePk/ParsePkGoBin_circuit20k-4       	       1	9541829245 ns/op
BenchmarkParsePk/ParsePkJson_circuit50k-4         	       1	25979727146 ns/op
BenchmarkParsePk/ParsePkBin_circuit50k-4          	       1	28434810627 ns/op
BenchmarkParsePk/ParsePkGoBin_circuit50k-4        	       1	23860248412 ns/op
```

The size of ProvingKey file for a circuit of 20k and 50k constraints:
```
circuit 20k constraints:
10097876 bytes of proving_key.go.bin
10097876 bytes of proving_key.bin
29760049 bytes of proving_key.json

circuit 50k constraints:
24195028 bytes of proving_key.go.bin
24194964 bytes of proving_key.bin
71484081 bytes of proving_key.json
```